### PR TITLE
chore: reference main branch of google-cloud-python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Python Client for Transcoder API
 - `Product Documentation`_
 
 .. |beta| image:: https://img.shields.io/badge/support-beta-orange.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#beta-support
+   :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#beta-support
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-video-transcoder.svg
    :target: https://pypi.org/project/google-cloud-video-transcoder/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-video-transcoder.svg
@@ -79,4 +79,4 @@ Next Steps
    APIs that we cover.
 
 .. _Transcoder API Product documentation:  https://cloud.google.com/transcoder/docs
-.. _README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
+.. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst


### PR DESCRIPTION
Adjust google-cloud-python links to reference main branch.