### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "transcoder",
     "name_pretty": "Transcoder",
     "product_documentation": "https://cloud.google.com/transcoder",
-    "client_documentation": "https://googleapis.dev/python/transcoder/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/transcoder/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python Client for Transcoder API
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-video-transcoder.svg
    :target: https://pypi.org/project/google-cloud-video-transcoder/
 .. _Transcoder API: https://cloud.google.com/transcoder
-.. _Client Library Documentation: https://googleapis.dev/python/transcoder/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/transcoder/latest
 .. _Product Documentation:  https://cloud.google.com/transcoder
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.